### PR TITLE
Alteration should return a Future

### DIFF
--- a/src/main/scala/com/gu/Box.scala
+++ b/src/main/scala/com/gu/Box.scala
@@ -2,8 +2,8 @@ package com.gu
 
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.concurrent.{Future, ExecutionContext}
-import scala.util.Try
+import scala.concurrent.Future
+import scala.util.{Try, Success, Failure}
 
 abstract class Box[T] {
   def get(): T
@@ -13,7 +13,7 @@ abstract class Box[T] {
   def send(f: T => T): Unit
 
   def alter(t: T): Future[T]
-  def alter(f: T => Try[T])(implicit ec: ExecutionContext): Future[T]
+  def alter(f: T => Try[T]): Future[T]
 
   def map[A](f: T => A): Box[A]
   def flatMap[A](f: T => Box[A]): Box[A]
@@ -33,8 +33,11 @@ private class AtomicRefBox[T](t: T) extends Box[T] {
   def send(f: T => T): Unit = ref.updateAndGet(t => f(t))
 
   def alter(t: T): Future[T] = Future.successful(ref.updateAndGet(_ => t))
-  def alter(f: T => Try[T])(implicit ec: ExecutionContext): Future[T] = 
-    Future.fromTry(f(t)).map(t => ref.updateAndGet(_ => t))
+  def alter(f: T => Try[T]): Future[T] = 
+    f(t) match {
+      case Success(v) => Future.successful(ref.updateAndGet(_ => v))
+      case Failure(e) => Future.failed(e)
+    }
 
   def map[A](f: T => A): Box[A] = new AtomicRefBox[A](f(get()))
   def flatMap[A](f: T => Box[A]): Box[A] = f(get())

--- a/src/main/scala/com/gu/Box.scala
+++ b/src/main/scala/com/gu/Box.scala
@@ -2,7 +2,8 @@ package com.gu
 
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Future, ExecutionContext}
+import scala.util.Try
 
 abstract class Box[T] {
   def get(): T
@@ -12,7 +13,7 @@ abstract class Box[T] {
   def send(f: T => T): Unit
 
   def alter(t: T): Future[T]
-  def alter(f: T => Future[T])(implicit ec: ExecutionContext): Future[T]
+  def alter(f: T => Try[T])(implicit ec: ExecutionContext): Future[T]
 
   def map[A](f: T => A): Box[A]
   def flatMap[A](f: T => Box[A]): Box[A]
@@ -32,7 +33,8 @@ private class AtomicRefBox[T](t: T) extends Box[T] {
   def send(f: T => T): Unit = ref.updateAndGet(t => f(t))
 
   def alter(t: T): Future[T] = Future.successful(ref.updateAndGet(_ => t))
-  def alter(f: T => Future[T])(implicit ec: ExecutionContext): Future[T] = f(t).map(t => ref.updateAndGet(_ => t))
+  def alter(f: T => Try[T])(implicit ec: ExecutionContext): Future[T] = 
+    Future.fromTry(f(t)).map(t => ref.updateAndGet(_ => t))
 
   def map[A](f: T => A): Box[A] = new AtomicRefBox[A](f(get()))
   def flatMap[A](f: T => Box[A]): Box[A] = f(get())

--- a/src/main/scala/com/gu/Box.scala
+++ b/src/main/scala/com/gu/Box.scala
@@ -2,7 +2,7 @@ package com.gu
 
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class Box[T] {
   def get(): T
@@ -12,7 +12,7 @@ abstract class Box[T] {
   def send(f: T => T): Unit
 
   def alter(t: T): Future[T]
-  def alter(f: T => T): Future[T]
+  def alter(f: T => Future[T])(implicit ec: ExecutionContext): Future[T]
 
   def map[A](f: T => A): Box[A]
   def flatMap[A](f: T => Box[A]): Box[A]
@@ -32,7 +32,7 @@ private class AtomicRefBox[T](t: T) extends Box[T] {
   def send(f: T => T): Unit = ref.updateAndGet(t => f(t))
 
   def alter(t: T): Future[T] = Future.successful(ref.updateAndGet(_ => t))
-  def alter(f: T => T): Future[T] = Future.successful(ref.updateAndGet(t => f(t)))
+  def alter(f: T => Future[T])(implicit ec: ExecutionContext): Future[T] = f(t).map(t => ref.updateAndGet(_ => t))
 
   def map[A](f: T => A): Box[A] = new AtomicRefBox[A](f(get()))
   def flatMap[A](f: T => Box[A]): Box[A] = f(get())


### PR DESCRIPTION
The `alter` method should account for possible failure at the calling site, so `T => T` just won't cut it.